### PR TITLE
BUILD-1287 Add .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/CODEOWNERS @SonarSource/languages-team-phpy


### PR DESCRIPTION
Set the team @SonarSource/languages-team as code owner in `.github/CODEOWNERS` file.

This is required by [BUILD-1271](https://jira.sonarsource.com/browse/BUILD-1271).
Contact @SonarSource/re-team for more information.
