### PR TITLE
Qualify S6249.py comments with rule IDs and clarify S6281 compliance

### DIFF
--- a/specific-rules/S6249.py
+++ b/specific-rules/S6249.py
@@ -1,14 +1,14 @@
 import aws_cdk.aws_iam as iam
 import aws_cdk.aws_s3 as s3
 
-no_config = s3.Bucket(self, "bucket")  # Noncompliant 
+no_config = s3.Bucket(self, "bucket")  # Noncompliant [S6249]
 
-ssl_false = s3.Bucket(self, "bucket", enforce_ssl=False)  # Noncompliant 
+ssl_false = s3.Bucket(self, "bucket", enforce_ssl=False)  # Noncompliant [S6249]
 
 
-with_config = s3.Bucket(self, "bucket")
+with_config = s3.Bucket(self, "bucket")  # S6281: Compliant (missing block_public_access is no longer flagged)
 
-result = with_config.add_to_resource_policy(iam.PolicyStatement(  # Noncompliant 
+result = with_config.add_to_resource_policy(iam.PolicyStatement(  # Noncompliant [S6249]
         effect=iam.Effect.DENY,
         resources=[bucket.bucket_arn],
         actions=["s3:SomeAction"],
@@ -17,12 +17,12 @@ result = with_config.add_to_resource_policy(iam.PolicyStatement(  # Noncompliant
     )
 )
 
-empty_policy_call = s3.Bucket(self, "bucket") # Noncompliant
+empty_policy_call = s3.Bucket(self, "bucket")  # Noncompliant [S6249]
 result = empty_policy_call.add_to_resource_policy()
 
-no_policy_added = s3.Bucket(self, "bucket") # Noncompliant
-result = no_policy_added.foo( 
-    iam.PolicyStatement(  
+no_policy_added = s3.Bucket(self, "bucket")  # Noncompliant [S6249]
+result = no_policy_added.foo(
+    iam.PolicyStatement(
         effect=iam.Effect.DENY,
         resources=["*"],
         actions=["s3:*"],
@@ -31,9 +31,9 @@ result = no_policy_added.foo(
     )
 )
 
-not_policy_statement = s3.Bucket(self, "bucket") # Noncompliant
-result = not_policy_statement.add_to_resource_policy( 
-    iam.Foo(  
+not_policy_statement = s3.Bucket(self, "bucket")  # Noncompliant [S6249]
+result = not_policy_statement.add_to_resource_policy(
+    iam.Foo(
         effect=iam.Effect.DENY,
         resources=["*"],
         actions=["s3:*"],
@@ -43,12 +43,12 @@ result = not_policy_statement.add_to_resource_policy(
 )
 from module import foo
 
-ssl_true = s3.Bucket(self, "bucket", enforce_ssl=True)  # Compliant
-ssl_unknown = s3.Bucket(self, "bucket", enforce_ssl=foo())  # Compliant
+ssl_true = s3.Bucket(self, "bucket", enforce_ssl=True)  # Compliant [S6249]
+ssl_unknown = s3.Bucket(self, "bucket", enforce_ssl=foo())  # Compliant [S6249]
 
-correct_policy = s3.Bucket(self, "bucket")
+correct_policy = s3.Bucket(self, "bucket")  # S6281: Compliant (missing block_public_access is no longer flagged)
 result = correct_policy.add_to_resource_policy(
-    iam.PolicyStatement(  # Compliant
+    iam.PolicyStatement(  # Compliant [S6249]
         effect=iam.Effect.DENY,
         resources=["*"],
         actions=["s3:*"],
@@ -57,9 +57,9 @@ result = correct_policy.add_to_resource_policy(
     )
 )
 
-compliant_policy = s3.Bucket(self, "bucket")
+compliant_policy = s3.Bucket(self, "bucket")  # S6281: Compliant (missing block_public_access is no longer flagged)
 result = compliant_policy.add_to_resource_policy(
-    iam.PolicyStatement(  # Compliant
+    iam.PolicyStatement(  # Compliant [S6249]
         effect=iam.Effect.DENY,
         resources=["foo", "*"],
         actions=["s3:*", "foo:foo"],


### PR DESCRIPTION
## Summary

- Qualified all existing `# Noncompliant` and `# Compliant` annotations in `S6249.py` with `[S6249]` to make clear which rule they refer to
- Added `# S6281: Compliant (missing block_public_access is no longer flagged)` to three `s3.Bucket()` instantiations that previously had no comment but were flagged by S6281's omitting case

## Context

S6281 (`S3BucketBlockPublicAccessCheck`) was updated to no longer raise an issue when `block_public_access` is omitted from an S3 bucket constructor. Previously, 10 lines in this file were flagged by S6281 for this reason. After the change, S6281 raises no issues here, and the ruling baseline was updated accordingly in sonar-python-enterprise.

The three lines that had no comment at all (lines 9, 49, 60) are the ones most in need of clarification, since a reader would otherwise have no hint that they were previously considered noncompliant by S6281.